### PR TITLE
Fixed date parsing and some JUnits

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ prettytable
 requests
 yapf
 pylint
+isodate

--- a/src/main/java/org/trd/app/teknichrono/business/view/LapTimeFilter.java
+++ b/src/main/java/org/trd/app/teknichrono/business/view/LapTimeFilter.java
@@ -24,7 +24,7 @@ public class LapTimeFilter {
     // Needs to be done here since we did not have all info before
     Map<Long, List<LapTimeDTO>> lapsPerLocation = new HashMap<>();
     for (LapTimeDTO dto : results) {
-      if (dto.getDuration() != null && dto.getDuration().compareTo(dto.getDuration()) > 0) {
+      if (dto.getDuration() != null && dto.getDuration().compareTo(Duration.ZERO) > 0) {
         NestedLocationDTO location = dto.getSession().getLocation();
         if (lapsPerLocation.containsKey(location.getId())) {
           lapsPerLocation.get(location.getId()).add(dto);
@@ -47,7 +47,7 @@ public class LapTimeFilter {
     for (LapTimeDTO lapTimeDTO : results) {
       NestedLocationDTO location = lapTimeDTO.getSession().getLocation();
       Duration averageOfLocation = averagePerLocation.get(location.getId());
-      if (averageOfLocation != null && lapTimeDTO.getDuration().compareTo(Duration.ZERO) > 0) {
+      if (averageOfLocation != null && lapTimeDTO.getDuration() != null && lapTimeDTO.getDuration().compareTo(Duration.ZERO) > 0) {
         if (lapTimeDTO.getDuration().compareTo(averageOfLocation.multipliedBy(ACCEPTANCE_FACTOR)) > 0) {
           logger.info("Discarding lap ID " + lapTimeDTO.getId()
               + " since it is too long (" + lapTimeDTO.getDuration() +
@@ -69,7 +69,7 @@ public class LapTimeFilter {
     Map<Long, LapTimeDTO> bests = new HashMap<>();
     List<LapTimeDTO> toRemove = new ArrayList<>();
     for (LapTimeDTO lapTimeDTO : results) {
-      if (lapTimeDTO.getDuration().compareTo(Duration.ZERO) <= 0) {
+      if (lapTimeDTO.getDuration() == null || lapTimeDTO.getDuration().compareTo(Duration.ZERO) <= 0) {
         toRemove.add(lapTimeDTO);
         continue;
       }

--- a/src/main/java/org/trd/app/teknichrono/business/view/LapTimeOrder.java
+++ b/src/main/java/org/trd/app/teknichrono/business/view/LapTimeOrder.java
@@ -31,7 +31,7 @@ public class LapTimeOrder {
         lapTimeDTO.setGapWithPrevious(Duration.ZERO);
       } else {
         Duration lapDuration = lapTimeDTO.getDuration();
-        if (lapDuration.compareTo(Duration.ZERO) > 0) {
+        if (lapDuration != null && lapDuration.compareTo(Duration.ZERO) > 0) {
           lapTimeDTO.setGapWithBest(lapDuration.minus(best).abs());
           lapTimeDTO.setGapWithPrevious(lapDuration.minus(previous).abs());
         }

--- a/src/main/java/org/trd/app/teknichrono/model/compare/LapTimeDTOComparator.java
+++ b/src/main/java/org/trd/app/teknichrono/model/compare/LapTimeDTOComparator.java
@@ -7,17 +7,19 @@ import java.util.Comparator;
 
 /**
  * Order by Duration then lap start
+ * <p>
+ * Laps with no duration are considered the greater (like infinite duration)
  */
 public class LapTimeDTOComparator implements Comparator<LapTimeDTO> {
 
   @Override
   public int compare(LapTimeDTO l1, LapTimeDTO l2) {
-    if (l1.getDuration().compareTo(Duration.ZERO) <= 0) {
-      if (l2.getDuration().compareTo(Duration.ZERO) <= 0) {
+    if (l1.getDuration() == null || l1.getDuration().compareTo(Duration.ZERO) <= 0) {
+      if (l2.getDuration() == null || l2.getDuration().compareTo(Duration.ZERO) <= 0) {
         return compareStartDate(l1, l2);
       }
       return 1;
-    } else if (l2.getDuration().compareTo(Duration.ZERO) <= 0) {
+    } else if (l2.getDuration() == null || l2.getDuration().compareTo(Duration.ZERO) <= 0) {
       return -1;
     } else {
       return l1.getDuration().compareTo(l2.getDuration());

--- a/src/main/java/org/trd/app/teknichrono/model/dto/NestedLocationDTO.java
+++ b/src/main/java/org/trd/app/teknichrono/model/dto/NestedLocationDTO.java
@@ -1,16 +1,15 @@
 package org.trd.app.teknichrono.model.dto;
 
-import java.io.Serializable;
+import org.trd.app.teknichrono.model.jpa.Location;
 
 import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
-
-import org.trd.app.teknichrono.model.jpa.Location;
+import java.io.Serializable;
 
 public class NestedLocationDTO implements Serializable {
 
   /**
-   * 
+   *
    */
   private static final long serialVersionUID = -1377429742860544608L;
 
@@ -50,11 +49,11 @@ public class NestedLocationDTO implements Serializable {
     return entity;
   }
 
-  public long getId() {
+  public Long getId() {
     return this.id;
   }
 
-  public void setId(final long id) {
+  public void setId(final Long id) {
     this.id = id;
   }
 

--- a/src/main/java/org/trd/app/teknichrono/model/dto/NestedSessionDTO.java
+++ b/src/main/java/org/trd/app/teknichrono/model/dto/NestedSessionDTO.java
@@ -1,17 +1,16 @@
 package org.trd.app.teknichrono.model.dto;
 
-import java.io.Serializable;
-import java.time.Instant;
+import org.trd.app.teknichrono.model.jpa.Session;
 
 import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
-
-import org.trd.app.teknichrono.model.jpa.Session;
+import java.io.Serializable;
+import java.time.Instant;
 
 public class NestedSessionDTO implements Serializable {
 
   /**
-   * 
+   *
    */
   private static final long serialVersionUID = 4519531688362345387L;
   private Long id;
@@ -69,11 +68,11 @@ public class NestedSessionDTO implements Serializable {
     return entity;
   }
 
-  public long getId() {
+  public Long getId() {
     return this.id;
   }
 
-  public void setId(final long id) {
+  public void setId(final Long id) {
     this.id = id;
   }
 

--- a/src/main/java/org/trd/app/teknichrono/model/dto/SectorDTO.java
+++ b/src/main/java/org/trd/app/teknichrono/model/dto/SectorDTO.java
@@ -1,22 +1,22 @@
 package org.trd.app.teknichrono.model.dto;
 
+import org.trd.app.teknichrono.model.jpa.Ping;
+
 import java.io.Serializable;
 import java.time.Duration;
 import java.time.Instant;
 
-import org.trd.app.teknichrono.model.jpa.Ping;
-
 public class SectorDTO implements Serializable {
 
   /**
-   * 
+   *
    */
   private static final long serialVersionUID = 4761496132411889132L;
 
   private Instant start;
   private Duration duration;
-  private long fromChronoId;
-  private long toChronoId;
+  private Long fromChronoId;
+  private Long toChronoId;
 
   public SectorDTO(final Ping from, final Ping to) {
     if (from != null && to != null) {
@@ -31,7 +31,7 @@ public class SectorDTO implements Serializable {
     this.start = start;
     this.duration = duration;
     this.fromChronoId = fromChronoId;
-    this.toChronoId = 0;
+    this.toChronoId = 0L;
   }
 
   @Override

--- a/src/test/java/org/trd/app/teknichrono/business/client/TestSessionSelector.java
+++ b/src/test/java/org/trd/app/teknichrono/business/client/TestSessionSelector.java
@@ -30,13 +30,13 @@ public class TestSessionSelector {
 
   @Before
   public void prepare() {
-    chrono.id++;
+    chrono.id = id++;
     ping.setChrono(chrono);
-    ping.id++;
+    ping.id = id++;
     ping.setInstant(now);
-    pilot.id++;
+    pilot.id = id++;
     beacon.setPilot(pilot);
-    beacon.id++;
+    beacon.id = id++;
     ping.setBeacon(beacon);
   }
 

--- a/src/test/java/org/trd/app/teknichrono/model/manage/TestLapTimeConverter.java
+++ b/src/test/java/org/trd/app/teknichrono/model/manage/TestLapTimeConverter.java
@@ -40,8 +40,8 @@ public class TestLapTimeConverter {
   }
 
   private void checkNoNegativeDuration(LapTimeDTO lap) {
-    Assert.assertTrue(lap.getDuration().compareTo(Duration.ZERO) >= 0);
-    Assert.assertTrue(lap.getGapWithBest().compareTo(Duration.ZERO) >= 0);
+    Assert.assertTrue(lap.getDuration() == null || lap.getDuration().compareTo(Duration.ZERO) > 0);
+    Assert.assertTrue(lap.getGapWithBest() == null || lap.getGapWithBest().compareTo(Duration.ZERO) >= 0);
     for (SectorDTO s : lap.getIntermediates()) {
 //      Assert.assertTrue(s.getStart() >= 0); // FIXME
       Assert.assertTrue("This intermediate duration is negative", s.getDuration().compareTo(Duration.ZERO) >= 0);

--- a/src/test/java/org/trd/app/teknichrono/model/manage/TestLapTimeOrder.java
+++ b/src/test/java/org/trd/app/teknichrono/model/manage/TestLapTimeOrder.java
@@ -16,6 +16,7 @@ import org.trd.app.teknichrono.model.jpa.TestLapTimeCreator;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class TestLapTimeOrder {
@@ -256,7 +257,7 @@ public class TestLapTimeOrder {
     Duration previousDuration = Duration.ZERO;
     Instant previousStart = Instant.MIN;
     for (LapTimeDTO l : laps) {
-      if (l.getDuration().compareTo(Duration.ZERO) > 0) {
+      if (l.getDuration() != null && l.getDuration().compareTo(Duration.ZERO) > 0) {
         Assert.assertTrue(l.getDuration().compareTo(previousDuration) >= 0);
         previousDuration = l.getDuration();
       } else {
@@ -287,16 +288,35 @@ public class TestLapTimeOrder {
     LapTimeOrder order = new LapTimeOrder();
     List<LapTimeDTO> laps = dtoCreator.createLaps();
     order.orderByDuration(laps);
+    laps.removeIf(l -> l.getDuration() == null);
     Duration previousGap = null;
 
     for (LapTimeDTO l : laps) {
       if (previousGap == null) {
         Assert.assertEquals(Duration.ZERO, l.getGapWithBest());
-      }
-      if (l.getDuration().compareTo(Duration.ZERO) > 0) {
+      } else if (l.getDuration() != null && l.getDuration().compareTo(Duration.ZERO) > 0) {
         Assert.assertTrue(l.getGapWithBest().compareTo(previousGap) >= 0);
       }
       previousGap = l.getGapWithBest();
+    }
+  }
+
+  @Test
+  public void lapsWithNoDurationAreLargest() {
+    LapTimeOrder order = new LapTimeOrder();
+    List<LapTimeDTO> laps = dtoCreator.createLaps();
+    order.orderByDuration(laps);
+    Collections.reverse(laps);
+    boolean firstWithNonNullDuration = false;
+
+    for (LapTimeDTO l : laps) {
+      if (firstWithNonNullDuration) {
+        Assert.assertNotNull(l.getDuration());
+      } else {
+        if (l.getDuration() != null) {
+          firstWithNonNullDuration = true;
+        }
+      }
     }
   }
 }

--- a/src/test/scripts/python/api/base.py
+++ b/src/test/scripts/python/api/base.py
@@ -5,6 +5,7 @@ import requests
 import json
 from datetime import date, datetime, timedelta
 import datetime as dt
+import isodate
 
 headers = {'Content-type': 'application/json'}
 debug = True
@@ -96,3 +97,10 @@ def pretty_time_delta(milliseconds):
     return '%d.%03d' % (seconds, milliseconds)
   else:
     return ''
+
+
+def pretty_time_delta_iso(time_iso):
+  timedeltaObject = isodate.parse_duration(time_iso)
+  milliseconds = (timedeltaObject / timedelta(microseconds=1000))
+  return pretty_time_delta(milliseconds)
+    

--- a/src/test/scripts/python/api/laps.py
+++ b/src/test/scripts/python/api/laps.py
@@ -107,17 +107,19 @@ def printLaps(laps, withDates=False):
     #lapId = str(lap['id'])
     startDateValue = lap['startDate']
     if startDateValue:
-      startDate = pretty_hour(startDateValue)
+      #startDate = pretty_hour(startDateValue)
+      startDate = startDateValue
     else:
       startDate = ''
     endDateValue = lap['endDate']
     if endDateValue:
-      endDate = pretty_hour(endDateValue)
+      #endDate = pretty_hour(endDateValue)
+      endDate = endDateValue
     else:
       endDate = ''
     pilot = str(lap['pilot']['firstName']) + ' ' + str(lap['pilot']['lastName'])
     lapIndex = str(lap['lapIndex']) + '/' + str(lap['lapNumber'])
-    lapTime = pretty_time_delta(lap['duration'])
+    lapTime = pretty_time_delta_iso(lap['duration'])
     lapRow = [str(rowIndex)]
     lapRow.append(str(lap['pilot']['beaconNumber']))
     if withDates:
@@ -137,10 +139,16 @@ def printLaps(laps, withDates=False):
           if intermediate['fromChronoId'] != i:
             lapRow.append('')
           else:
-            lapRow.append(pretty_time_delta(intermediate['duration']))
+            lapRow.append(pretty_time_delta_iso(intermediate['duration']))
             intermediateIndex += 1
-    lapRow.append(pretty_time_delta(lap['gapWithBest']))
-    lapRow.append(pretty_time_delta(lap['gapWithPrevious']))
+    if 'gapWithBest' in lap:
+      lapRow.append(pretty_time_delta_iso(lap['gapWithBest']))
+    else:
+      lapRow.append('-')
+    if 'gapWithPrevious' in lap:
+      lapRow.append(pretty_time_delta_iso(lap['gapWithPrevious']))
+    else:
+      lapRow.append('-')
     table.add_row(lapRow)
     rowIndex += +1
   print(table)


### PR DESCRIPTION
With this level of code, I have this issue with Integration tests
```
2019-05-19 22:36:52,637 ERROR [io.und.request] (executor-thread-3) UT005023: Exception handling request to /rest/sessions/name: org.jboss.resteasy.spi.UnhandledException: java.lang.ExceptionInInitializerError
	at org.jboss.resteasy.core.ExceptionHandler.handleApplicationException(ExceptionHandler.java:106)
	at org.jboss.resteasy.core.ExceptionHandler.handleException(ExceptionHandler.java:372)
	at org.jboss.resteasy.core.SynchronousDispatcher.writeException(SynchronousDispatcher.java:209)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:496)
	at org.jboss.resteasy.core.SynchronousDispatcher.lambda$invoke$4(SynchronousDispatcher.java:252)
	at org.jboss.resteasy.core.SynchronousDispatcher.lambda$preprocess$0(SynchronousDispatcher.java:153)
	at org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext.filter(PreMatchContainerRequestContext.java:362)
	at org.jboss.resteasy.core.SynchronousDispatcher.preprocess(SynchronousDispatcher.java:156)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:238)
	at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:234)
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:61)
	at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:56)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:791)
	at io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:74)
	at io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:62)
	at io.undertow.servlet.handlers.ServletChain$1.handleRequest(ServletChain.java:68)
	at io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36)
	at io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:132)
	at io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:57)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:46)
	at io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:64)
	at io.undertow.security.handlers.AuthenticationMechanismsHandler.handleRequest(AuthenticationMechanismsHandler.java:60)
	at io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:77)
	at io.undertow.security.handlers.AbstractSecurityContextAssociationHandler.handleRequest(AbstractSecurityContextAssociationHandler.java:43)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:292)
	at io.undertow.servlet.handlers.ServletInitialHandler.access$100(ServletInitialHandler.java:81)
	at io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:138)
	at io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:135)
	at io.undertow.servlet.core.ServletRequestContextThreadSetupAction$1.call(ServletRequestContextThreadSetupAction.java:48)
	at io.undertow.servlet.core.ContextClassLoaderSetupAction$1.call(ContextClassLoaderSetupAction.java:43)
	at io.quarkus.undertow.runtime.UndertowDeploymentTemplate$7$1$1.call(UndertowDeploymentTemplate.java:437)
	at io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:272)
	at io.undertow.servlet.handlers.ServletInitialHandler.handleRequest(ServletInitialHandler.java:197)
	at io.undertow.server.handlers.HttpContinueReadHandler.handleRequest(HttpContinueReadHandler.java:65)
	at io.quarkus.undertow.runtime.UndertowDeploymentTemplate$1.handleRequest(UndertowDeploymentTemplate.java:96)
	at io.undertow.server.handlers.CanonicalPathHandler.handleRequest(CanonicalPathHandler.java:49)
	at io.quarkus.undertow.deployment.devmode.UndertowHotReplacementSetup.handleHotDeploymentRequest(UndertowHotReplacementSetup.java:65)
	at io.quarkus.undertow.deployment.devmode.UndertowHotReplacementSetup$1$1.handleRequest(UndertowHotReplacementSetup.java:51)
	at io.undertow.server.Connectors.executeRootHandler(Connectors.java:364)
	at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:830)
	at org.jboss.threads.ContextClassLoaderSavingRunnable.run(ContextClassLoaderSavingRunnable.java:35)
	at org.jboss.threads.EnhancedQueueExecutor.safeRun(EnhancedQueueExecutor.java:2011)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.doRunTask(EnhancedQueueExecutor.java:1538)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1429)
	at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:29)
	at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:32)
	at java.lang.Thread.run(Thread.java:745)
	at org.jboss.threads.JBossThread.run(JBossThread.java:479)
Caused by: java.lang.ExceptionInInitializerError
	at org.trd.app.teknichrono.rest.SessionEndpoint.findSessionByName(SessionEndpoint.java:157)
	at org.trd.app.teknichrono.rest.SessionEndpoint_Subclass.findSessionByName$$superaccessor20(Unknown Source)
	at org.trd.app.teknichrono.rest.SessionEndpoint_Subclass$$function$$21.apply(Unknown Source)
	at io.quarkus.arc.InvocationContextImpl.interceptorChainCompleted(InvocationContextImpl.java:157)
	at io.quarkus.arc.InvocationContextImpl.proceed(InvocationContextImpl.java:177)
	at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorBase.invokeInOurTx(TransactionalInterceptorBase.java:94)
	at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorRequired.doIntercept(TransactionalInterceptorRequired.java:48)
	at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorBase.intercept(TransactionalInterceptorBase.java:60)
	at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorRequired.intercept(TransactionalInterceptorRequired.java:42)
	at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorRequired_Bean.intercept(Unknown Source)
	at io.quarkus.arc.InvocationContextImpl$InterceptorInvocation.invoke(InvocationContextImpl.java:270)
	at io.quarkus.arc.InvocationContextImpl.invokeNext(InvocationContextImpl.java:149)
	at io.quarkus.arc.InvocationContextImpl.proceed(InvocationContextImpl.java:173)
	at org.trd.app.teknichrono.rest.SessionEndpoint_Subclass.findSessionByName(Unknown Source)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:151)
	at org.jboss.resteasy.core.MethodInjectorImpl.lambda$invoke$3(MethodInjectorImpl.java:122)
	at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:602)
	at java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:614)
	at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:1983)
	at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:110)
	at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:122)
	at org.jboss.resteasy.core.ResourceMethodInvoker.internalInvokeOnTarget(ResourceMethodInvoker.java:568)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTargetAfterFilter(ResourceMethodInvoker.java:442)
	at org.jboss.resteasy.core.ResourceMethodInvoker.lambda$invokeOnTarget$2(ResourceMethodInvoker.java:396)
	at org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext.filter(PreMatchContainerRequestContext.java:362)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTarget(ResourceMethodInvoker.java:398)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:367)
	at org.jboss.resteasy.core.ResourceMethodInvoker.lambda$invoke$1(ResourceMethodInvoker.java:341)
	at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:981)
	at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2124)
	at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:110)
	at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:341)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:477)
	... 47 more
Caused by: java.lang.IllegalArgumentException: Unable to load generated mapper class org.trd.app.teknichrono.model.dto.mapper.SessionMapperSelmaGeneratedClass failed : org.trd.app.teknichrono.model.dto.mapper.SessionMapperSelmaGeneratedClass
	at fr.xebia.extras.selma.Selma.createMapperInstance(Selma.java:255)
	at fr.xebia.extras.selma.Selma.getMapper(Selma.java:158)
	at fr.xebia.extras.selma.Selma.access$100(Selma.java:56)
	at fr.xebia.extras.selma.Selma$MapperBuilder.build(Selma.java:349)
	at org.trd.app.teknichrono.model.dto.SessionDTO.<clinit>(SessionDTO.java:17)
	... 84 more
Caused by: java.lang.ClassNotFoundException: org.trd.app.teknichrono.model.dto.mapper.SessionMapperSelmaGeneratedClass
	at io.quarkus.runner.RuntimeClassLoader.findClass(RuntimeClassLoader.java:217)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at io.quarkus.runner.RuntimeClassLoader.loadClass(RuntimeClassLoader.java:154)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at fr.xebia.extras.selma.Selma.createMapperInstance(Selma.java:183)
	... 88 more```