### PR TITLE
Change the results windowing results to a Page-based model

### DIFF
--- a/src/main/java/org/trd/app/teknichrono/model/jpa/PanacheRepositoryWrapper.java
+++ b/src/main/java/org/trd/app/teknichrono/model/jpa/PanacheRepositoryWrapper.java
@@ -20,9 +20,9 @@ abstract class PanacheRepositoryWrapper<T> implements Repository<T> {
     }
 
     @Override
-    public Stream<T> findAll(Integer startPosition, Integer maxResult) {
+    public Stream<T> findAll(Integer pageIndex, Integer pageSize) {
         return panacheRepository.findAll()
-                .page(Paging.from(startPosition, maxResult))
+                .page(Paging.from(pageIndex, pageSize))
                 .stream();
     }
 

--- a/src/main/java/org/trd/app/teknichrono/model/jpa/Repository.java
+++ b/src/main/java/org/trd/app/teknichrono/model/jpa/Repository.java
@@ -8,7 +8,16 @@ public interface Repository<T> {
 
     T findById(Long id);
 
-    Stream<T> findAll(Integer startPosition, Integer maxResult);
+    /**
+     * Returns up to <code>pageSize</code> results starting from <code>pageIndex * pageSize</code>
+     *
+     * @param pageIndex the index (0-based) of the result page you want to get.
+     *                  If <code>null</code>, then the first page (index 0) is assumed.
+     * @param pageSize  the size of each page.
+     *                  If <code>null</code>, <code>Integer.MAX_VALUE</code> is assumed.
+     * @return up to <code>pageSize</code> results starting from <code>pageIndex * pageSize</code>
+     */
+    Stream<T> findAll(Integer pageIndex, Integer pageSize);
 
     void persist(T entity);
 

--- a/src/main/java/org/trd/app/teknichrono/rest/BeaconEndpoint.java
+++ b/src/main/java/org/trd/app/teknichrono/rest/BeaconEndpoint.java
@@ -113,9 +113,9 @@ public class BeaconEndpoint {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Transactional
-  public List<BeaconDTO> listAll(@QueryParam("start") Integer startPosition, @QueryParam("max") Integer maxResult) {
+  public List<BeaconDTO> listAll(@QueryParam("page") Integer pageIndex, @QueryParam("pageSize") Integer pageSize) {
     DurationLogger perf = DurationLogger.get(LOGGER).start("Find all beacons");
-    List<BeaconDTO> results = beaconRepository.findAll(startPosition, maxResult)
+    List<BeaconDTO> results = beaconRepository.findAll(pageIndex, pageSize)
             .map(BeaconDTO::fromBeacon)
             .collect(Collectors.toList());
     perf.end();

--- a/src/main/java/org/trd/app/teknichrono/rest/CategoryEndpoint.java
+++ b/src/main/java/org/trd/app/teknichrono/rest/CategoryEndpoint.java
@@ -98,9 +98,9 @@ public class CategoryEndpoint {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Transactional
-  public List<CategoryDTO> listAll(@QueryParam("start") Integer startPosition, @QueryParam("max") Integer maxResult) {
+  public List<CategoryDTO> listAll(@QueryParam("page") Integer pageIndex, @QueryParam("pageSize") Integer pageSize) {
     try (DurationLogger perf = DurationLogger.get(LOGGER).start("Find all categories")) {
-      return categoryRepository.findAll(startPosition, maxResult)
+      return categoryRepository.findAll(pageIndex, pageSize)
               .map(CategoryDTO::fromCategory)
               .collect(Collectors.toList());
     }

--- a/src/main/java/org/trd/app/teknichrono/rest/ChronometerEndpoint.java
+++ b/src/main/java/org/trd/app/teknichrono/rest/ChronometerEndpoint.java
@@ -110,10 +110,10 @@ public class ChronometerEndpoint {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  public List<ChronometerDTO> listAll(@QueryParam("start") Integer startPosition, @QueryParam("max") Integer maxResult) {
+  public List<ChronometerDTO> listAll(@QueryParam("page") Integer pageIndex, @QueryParam("pageSize") Integer pageSize) {
     try (DurationLogger dl = new DurationLogger(LOGGER, "Get all chronometers")) {
       return chronometerRepository.findAll()
-          .page(Paging.from(startPosition, maxResult))
+          .page(Paging.from(pageIndex, pageSize))
           .stream()
           .map(ChronometerDTO::fromChronometer)
           .collect(Collectors.toList());

--- a/src/main/java/org/trd/app/teknichrono/rest/EventEndpoint.java
+++ b/src/main/java/org/trd/app/teknichrono/rest/EventEndpoint.java
@@ -89,9 +89,9 @@ public class EventEndpoint {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Transactional
-  public List<EventDTO> listAll(@QueryParam("start") Integer startPosition, @QueryParam("max") Integer maxResult) {
+  public List<EventDTO> listAll(@QueryParam("page") Integer pageIndex, @QueryParam("pageSize") Integer pageSize) {
     return eventRepository.findAll()
-            .page(Paging.from(startPosition, maxResult))
+            .page(Paging.from(pageIndex, pageSize))
             .stream()
             .map(EventDTO::fromEvent)
             .collect(Collectors.toList());

--- a/src/main/java/org/trd/app/teknichrono/rest/LocationEndpoint.java
+++ b/src/main/java/org/trd/app/teknichrono/rest/LocationEndpoint.java
@@ -85,9 +85,9 @@ public class LocationEndpoint {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Transactional
-  public List<LocationDTO> listAll(@QueryParam("start") Integer startPosition, @QueryParam("max") Integer maxResult) {
+  public List<LocationDTO> listAll(@QueryParam("page") Integer pageIndex, @QueryParam("pageSize") Integer pageSize) {
     return locationRepository.findAll()
-            .page(Paging.from(startPosition, maxResult))
+            .page(Paging.from(pageIndex, pageSize))
             .stream()
             .map(LocationDTO::fromLocation)
             .collect(Collectors.toList());

--- a/src/main/java/org/trd/app/teknichrono/rest/Paging.java
+++ b/src/main/java/org/trd/app/teknichrono/rest/Paging.java
@@ -6,18 +6,22 @@ public class Paging {
 
     private static final int DEFAULT_PAGE_SIZE = Integer.MAX_VALUE;
 
-    public static Page from(Integer startPosition, Integer maxResults) {
-        int pageIndex;
-        int pageSize;
-        if (maxResults == null) {
-            pageSize = DEFAULT_PAGE_SIZE;
-        } else {
-            pageSize = maxResults;
-        }
-        if (startPosition == null) {
+    /**
+     * Returns a Page with appropriates defaults. When using a Page,
+     * up to <code>pageSize</code> results starting from <code>pageIndex * pageSize</code> will be returned.
+     *
+     * @param pageIndex the index (0-based) of the result page you want to get.
+     *                  If <code>null</code>, then the first page (index 0) is assumed.
+     * @param pageSize  the size of each page.
+     *                  If <code>null</code>, <code>Integer.MAX_VALUE</code> is assumed.
+     * @return a Page with appropriates defaults.
+     */
+    public static Page from(Integer pageIndex, Integer pageSize) {
+        if (pageIndex == null) {
             pageIndex = 0;
-        } else {
-            pageIndex = startPosition / pageSize;
+        }
+        if (pageSize == null) {
+            pageSize = DEFAULT_PAGE_SIZE;
         }
         return Page.of(pageIndex, pageSize);
     }

--- a/src/main/java/org/trd/app/teknichrono/rest/PilotEndpoint.java
+++ b/src/main/java/org/trd/app/teknichrono/rest/PilotEndpoint.java
@@ -102,8 +102,8 @@ public class PilotEndpoint {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Transactional
-  public List<PilotDTO> listAll(@QueryParam("start") Integer startPosition, @QueryParam("max") Integer maxResult) {
-    return pilotRepository.findAll().page(Paging.from(startPosition, maxResult)).stream().map(PilotDTO::fromPilot)
+  public List<PilotDTO> listAll(@QueryParam("page") Integer pageIndex, @QueryParam("pageSize") Integer pageSize) {
+    return pilotRepository.findAll().page(Paging.from(pageIndex, pageSize)).stream().map(PilotDTO::fromPilot)
         .collect(Collectors.toList());
   }
 

--- a/src/main/java/org/trd/app/teknichrono/rest/PingEndpoint.java
+++ b/src/main/java/org/trd/app/teknichrono/rest/PingEndpoint.java
@@ -108,9 +108,9 @@ public class PingEndpoint {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Transactional
-  public List<NestedPingDTO> listAll(@QueryParam("start") Integer startPosition, @QueryParam("max") Integer maxResult) {
+  public List<NestedPingDTO> listAll(@QueryParam("page") Integer pageIndex, @QueryParam("pageSize") Integer pageSize) {
     return pingRepository.findAll()
-            .page(Paging.from(startPosition, maxResult))
+            .page(Paging.from(pageIndex, pageSize))
             .stream()
             .map(NestedPingDTO::fromPing)
             .collect(Collectors.toList());

--- a/src/main/java/org/trd/app/teknichrono/rest/SessionEndpoint.java
+++ b/src/main/java/org/trd/app/teknichrono/rest/SessionEndpoint.java
@@ -168,17 +168,17 @@ public class SessionEndpoint {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Transactional
-  public List<SessionDTO> listAll(@QueryParam("start") Integer startPosition, @QueryParam("max") Integer maxResult) {
+  public List<SessionDTO> listAll(@QueryParam("page") Integer pageIndex, @QueryParam("pageSize") Integer pageSize) {
     DurationLogger perf = DurationLogger.get(logger).start("List sessions");
-    List<SessionDTO> sessions = listAllSessions(startPosition, maxResult)
+    List<SessionDTO> sessions = listAllSessions(pageIndex, pageSize)
         .map(SessionDTO::fromSession)
         .collect(Collectors.toList());
     perf.end();
     return sessions;
   }
 
-  private Stream<Session> listAllSessions(Integer startPosition, Integer maxResult) {
-    return sessionRepository.findAll().page(Paging.from(startPosition, maxResult)).stream();
+  private Stream<Session> listAllSessions(Integer pageIndex, Integer pageSize) {
+    return sessionRepository.findAll().page(Paging.from(pageIndex, pageSize)).stream();
   }
 
   @POST

--- a/src/test/java/org/trd/app/teknichrono/it/TestRestBeaconEndpoint.java
+++ b/src/test/java/org/trd/app/teknichrono/it/TestRestBeaconEndpoint.java
@@ -92,8 +92,8 @@ public class TestRestBeaconEndpoint {
     }.getClass().getGenericSuperclass());
   }
 
-  public List<BeaconDTO> getAllBeaconsWindow(int start, int max) {
-    Response r = given().queryParam("start", Integer.valueOf(start)).queryParam("max", Integer.valueOf(max))
+  public List<BeaconDTO> getAllBeaconsWindow(int page, int pageSize) {
+    Response r = given().queryParam("page", page).queryParam("pageSize", pageSize)
         .when().get("/rest/beacons")
         .then()
         .statusCode(200)

--- a/src/test/java/org/trd/app/teknichrono/it/TestRestCategoryEndpoint.java
+++ b/src/test/java/org/trd/app/teknichrono/it/TestRestCategoryEndpoint.java
@@ -91,8 +91,8 @@ public class TestRestCategoryEndpoint {
     }.getClass().getGenericSuperclass());
   }
 
-  public List<CategoryDTO> getAllCategoriesWindow(int start, int max) {
-    Response r = given().queryParam("start", Integer.valueOf(start)).queryParam("max", Integer.valueOf(max))
+  public List<CategoryDTO> getAllCategoriesWindow(int page, int pageSize) {
+    Response r = given().queryParam("page", page).queryParam("pageSize", pageSize)
         .when().get("/rest/categories")
         .then()
         .statusCode(200)


### PR DESCRIPTION
Developing with `startIndex` and `maxResults` concepts for list retrieval is indeed powerful and flexible but requires some unnecessary complexity on the UI side when all you want is just a paging system.

This PR migrates the server side to the Paging model of Quarkus using `page` and `pageSize` concepts instead of `startIndex` and `maxResults`.

This PR only contains the server side changes for now.
Let me know if you're fine with this principle. If yes, I'll then update the PR with the UI part of the change.